### PR TITLE
 Remove `%{random_suffix}` from resource docs

### DIFF
--- a/website/docs/r/access_context_manager_access_level_condition.html.markdown
+++ b/website/docs/r/access_context_manager_access_level_condition.html.markdown
@@ -50,8 +50,8 @@ Your account must have the `serviceusage.services.use` permission on the
 ```hcl
 resource "google_access_context_manager_access_level" "access-level-service-account" {
   parent = "accessPolicies/${google_access_context_manager_access_policy.access-policy.name}"
-  name   = "accessPolicies/${google_access_context_manager_access_policy.access-policy.name}/accessLevels/tf_test_chromeos_no_lock%{random_suffix}"
-  title  = "tf_test_chromeos_no_lock%{random_suffix}"
+  name   = "accessPolicies/${google_access_context_manager_access_policy.access-policy.name}/accessLevels/tf_test_chromeos_no_lock"
+  title  = "tf_test_chromeos_no_lock"
   basic {
     conditions {
       device_policy {
@@ -74,7 +74,7 @@ resource "google_access_context_manager_access_level" "access-level-service-acco
 }
 
 resource "google_service_account" "created-later" {
-  account_id = "tf-test-%{random_suffix}"
+  account_id = "tf-test"
 }
 
 resource "google_access_context_manager_access_level_condition" "access-level-conditions" {

--- a/website/docs/r/apigee_envgroup.html.markdown
+++ b/website/docs/r/apigee_envgroup.html.markdown
@@ -63,7 +63,7 @@ resource "google_apigee_organization" "apigee_org" {
 }
 
 resource "google_apigee_envgroup" "env_grp" {
-  name      = "tf-test%{random_suffix}"
+  name      = "tf-test"
   hostnames = ["abc.foo.com"]
   org_id    = google_apigee_organization.apigee_org.id
 }

--- a/website/docs/r/apigee_envgroup_attachment.html.markdown
+++ b/website/docs/r/apigee_envgroup_attachment.html.markdown
@@ -36,8 +36,8 @@ To get more information about EnvgroupAttachment, see:
 
 ```hcl
 resource "google_project" "project" {
-  project_id      = "tf-test%{random_suffix}"
-  name            = "tf-test%{random_suffix}"
+  project_id      = "tf-test"
+  name            = "tf-test"
   org_id          = ""
   billing_account = ""
 }
@@ -91,15 +91,15 @@ resource "google_apigee_organization" "apigee_org" {
 
 resource "google_apigee_envgroup" "apigee_envgroup" {
   org_id    = google_apigee_organization.apigee_org.id
-  name      = "tf-test%{random_suffix}"
+  name      = "tf-test"
   hostnames = ["abc.foo.com"]
 }
 
 resource "google_apigee_environment" "apigee_env" {
   org_id       = google_apigee_organization.apigee_org.id
-  name         = "tf-test%{random_suffix}"
+  name         = "tf-test"
   description  = "Apigee Environment"
-  display_name = "tf-test%{random_suffix}"
+  display_name = "tf-test"
 }
 
 resource "google_apigee_envgroup_attachment" "" {

--- a/website/docs/r/apigee_environment.html.markdown
+++ b/website/docs/r/apigee_environment.html.markdown
@@ -63,7 +63,7 @@ resource "google_apigee_organization" "apigee_org" {
 }
 
 resource "google_apigee_environment" "env" {
-  name         = "tf-test%{random_suffix}"
+  name         = "tf-test"
   description  = "Apigee Environment"
   display_name = "environment-1"
   org_id       = google_apigee_organization.apigee_org.id

--- a/website/docs/r/apigee_instance.html.markdown
+++ b/website/docs/r/apigee_instance.html.markdown
@@ -63,7 +63,7 @@ resource "google_apigee_organization" "apigee_org" {
 }
 
 resource "google_apigee_instance" "apigee_instance" {
-  name     = "tf-test%{random_suffix}"
+  name     = "tf-test"
   location = "us-central1"
   org_id   = google_apigee_organization.apigee_org.id
 }
@@ -100,7 +100,7 @@ resource "google_apigee_organization" "apigee_org" {
 }
 
 resource "google_apigee_instance" "apigee_instance" {
-  name     = "tf-test%{random_suffix}"
+  name     = "tf-test"
   location = "us-central1"
   org_id   = google_apigee_organization.apigee_org.id
   peering_cidr_range = "SLASH_22"
@@ -138,7 +138,7 @@ resource "google_apigee_organization" "apigee_org" {
 }
 
 resource "google_apigee_instance" "apigee_instance" {
-  name     = "tf-test%{random_suffix}"
+  name     = "tf-test"
   location = "us-central1"
   org_id   = google_apigee_organization.apigee_org.id
   ip_range = "10.87.8.0/22"
@@ -212,10 +212,10 @@ resource "google_apigee_organization" "apigee_org" {
 }
 
 resource "google_apigee_instance" "apigee_instance" {
-  name                     = "tf-test%{random_suffix}"
+  name                     = "tf-test"
   location                 = "us-central1"
   description	             = "Auto-managed Apigee Runtime Instance"
-  display_name             = "tf-test%{random_suffix}"
+  display_name             = "tf-test"
   org_id                   = google_apigee_organization.apigee_org.id
   disk_encryption_key_name = google_kms_crypto_key.apigee_key.id
 }

--- a/website/docs/r/apigee_instance_attachment.html.markdown
+++ b/website/docs/r/apigee_instance_attachment.html.markdown
@@ -36,8 +36,8 @@ To get more information about InstanceAttachment, see:
 
 ```hcl
 resource "google_project" "project" {
-  project_id      = "tf-test%{random_suffix}"
-  name            = "tf-test%{random_suffix}"
+  project_id      = "tf-test"
+  name            = "tf-test"
   org_id          = ""
   billing_account = ""
 }
@@ -90,14 +90,14 @@ resource "google_apigee_organization" "apigee_org" {
 }
 
 resource "google_apigee_instance" "apigee_ins" {
-  name     = "tf-test%{random_suffix}"
+  name     = "tf-test"
   location = "us-central1"
   org_id   = google_apigee_organization.apigee_org.id
 }
 
 resource "google_apigee_environment" "apigee_env" {
   org_id   = google_apigee_organization.apigee_org.id
-  name         = "tf-test%{random_suffix}"
+  name         = "tf-test"
   description  = "Apigee Environment"
   display_name = "environment-1"
 }

--- a/website/docs/r/bigquery_reservation_assignment.html.markdown
+++ b/website/docs/r/bigquery_reservation_assignment.html.markdown
@@ -28,7 +28,7 @@ The BigqueryReservation Assignment resource
 ## Example Usage - basic
 ```hcl
 resource "google_bigquery_reservation" "basic" {
-  name  = "tf-test-my-reservation%{random_suffix}"
+  name  = "tf-test-my-reservation"
   project = "my-project-name"
   location = "us-central1"
   slot_capacity = 0

--- a/website/docs/r/bigquery_routine.html.markdown
+++ b/website/docs/r/bigquery_routine.html.markdown
@@ -67,7 +67,7 @@ resource "google_bigquery_dataset" "test" {
 
 resource "google_bigquery_routine" "sproc" {
   dataset_id = google_bigquery_dataset.test.dataset_id
-  routine_id     = "tf_test_routine_id%{random_suffix}"
+  routine_id     = "tf_test_routine_id"
   routine_type = "SCALAR_FUNCTION"
   language = "JAVASCRIPT"
   definition_body = "CREATE FUNCTION multiplyInputs return x*y;"
@@ -98,7 +98,7 @@ resource "google_bigquery_dataset" "test" {
 
 resource "google_bigquery_routine" "sproc" {
   dataset_id      = google_bigquery_dataset.test.dataset_id
-  routine_id      = "tf_test_routine_id%{random_suffix}"
+  routine_id      = "tf_test_routine_id"
   routine_type    = "TABLE_VALUED_FUNCTION"
   language        = "SQL"
   definition_body = <<-EOS

--- a/website/docs/r/compute_global_address.html.markdown
+++ b/website/docs/r/compute_global_address.html.markdown
@@ -65,7 +65,7 @@ resource "google_compute_global_address" "default" {
 
 resource "google_compute_network" "network" {
   provider      = google-beta
-  name          = "tf-test%{random_suffix}"
+  name          = "tf-test"
   auto_create_subnetworks = false
 }
 ```

--- a/website/docs/r/compute_organization_security_policy.html.markdown
+++ b/website/docs/r/compute_organization_security_policy.html.markdown
@@ -36,7 +36,7 @@ To get more information about OrganizationSecurityPolicy, see:
 ```hcl
 resource "google_compute_organization_security_policy" "policy" {
   provider = google-beta
-  display_name = "tf-test%{random_suffix}"
+  display_name = "tf-test"
   parent       = "organizations/123456789"
 }
 ```

--- a/website/docs/r/compute_organization_security_policy_association.html.markdown
+++ b/website/docs/r/compute_organization_security_policy_association.html.markdown
@@ -36,13 +36,13 @@ To get more information about OrganizationSecurityPolicyAssociation, see:
 ```hcl
 resource "google_folder" "security_policy_target" {
   provider     = google-beta
-  display_name = "tf-test-secpol-%{random_suffix}"
+  display_name = "tf-test-secpol"
   parent       = "organizations/123456789"
 }
 
 resource "google_compute_organization_security_policy" "policy" {
   provider = google-beta
-  display_name = "tf-test%{random_suffix}"
+  display_name = "tf-test"
   parent       = google_folder.security_policy_target.name
 }
 
@@ -70,7 +70,7 @@ resource "google_compute_organization_security_policy_rule" "policy" {
 
 resource "google_compute_organization_security_policy_association" "policy" {
   provider = google-beta
-  name          = "tf-test%{random_suffix}"
+  name          = "tf-test"
   attachment_id = google_compute_organization_security_policy.policy.parent
   policy_id     = google_compute_organization_security_policy.policy.id
 }

--- a/website/docs/r/compute_organization_security_policy_rule.html.markdown
+++ b/website/docs/r/compute_organization_security_policy_rule.html.markdown
@@ -36,7 +36,7 @@ To get more information about OrganizationSecurityPolicyRule, see:
 ```hcl
 resource "google_compute_organization_security_policy" "policy" {
   provider = google-beta
-  display_name = "tf-test%{random_suffix}"
+  display_name = "tf-test"
   parent       = "organizations/123456789"
 }
 

--- a/website/docs/r/compute_per_instance_config.html.markdown
+++ b/website/docs/r/compute_per_instance_config.html.markdown
@@ -76,7 +76,7 @@ resource "google_compute_instance_group_manager" "igm-no-tp" {
 }
 
 resource "google_compute_disk" "default" {
-  name  = "test-disk-%{random_suffix}"
+  name  = "test-disk"
   type  = "pd-ssd"
   zone  = google_compute_instance_group_manager.igm.zone
   image = "debian-8-jessie-v20170523"

--- a/website/docs/r/compute_region_per_instance_config.html.markdown
+++ b/website/docs/r/compute_region_per_instance_config.html.markdown
@@ -83,7 +83,7 @@ resource "google_compute_region_instance_group_manager" "rigm" {
 }
 
 resource "google_compute_disk" "default" {
-  name  = "test-disk-%{random_suffix}"
+  name  = "test-disk"
   type  = "pd-ssd"
   zone  = "us-central1-a"
   image = "debian-8-jessie-v20170523"

--- a/website/docs/r/dialogflow_intent.html.markdown
+++ b/website/docs/r/dialogflow_intent.html.markdown
@@ -52,8 +52,8 @@ resource "google_dialogflow_intent" "basic_intent" {
 
 ```hcl
 resource "google_project" "agent_project" {
-  project_id = "tf-test-dialogflow-%{random_suffix}"
-  name = "tf-test-dialogflow-%{random_suffix}"
+  project_id = "tf-test-dialogflow"
+  name = "tf-test-dialogflow"
   org_id = "123456789"
 }
 
@@ -64,7 +64,7 @@ resource "google_project_service" "agent_project" {
 }
 
 resource "google_service_account" "dialogflow_service_account" {
-  account_id = "tf-test-dialogflow-%{random_suffix}"
+  account_id = "tf-test-dialogflow"
 }
 
 resource "google_project_iam_member" "agent_create" {

--- a/website/docs/r/firebase_project.html.markdown
+++ b/website/docs/r/firebase_project.html.markdown
@@ -41,8 +41,8 @@ To get more information about Project, see:
 resource "google_project" "default" {
   provider = google-beta
 
-  project_id = "tf-test%{random_suffix}"
-  name       = "tf-test%{random_suffix}"
+  project_id = "tf-test"
+  name       = "tf-test"
   org_id     = "123456789"
 }
 

--- a/website/docs/r/firebase_project_location.html.markdown
+++ b/website/docs/r/firebase_project_location.html.markdown
@@ -46,8 +46,8 @@ To get more information about ProjectLocation, see:
 resource "google_project" "default" {
   provider = google-beta
 
-  project_id = "tf-test%{random_suffix}"
-  name       = "tf-test%{random_suffix}"
+  project_id = "tf-test"
+  name       = "tf-test"
   org_id     = "123456789"
 }
 

--- a/website/docs/r/firebase_web_app.html.markdown
+++ b/website/docs/r/firebase_web_app.html.markdown
@@ -37,8 +37,8 @@ To get more information about WebApp, see:
 resource "google_project" "default" {
 	provider = google-beta
 
-	project_id = "tf-test%{random_suffix}"
-	name       = "tf-test%{random_suffix}"
+	project_id = "tf-test"
+	name       = "tf-test"
 	org_id     = "123456789"
 }
 

--- a/website/docs/r/firestore_document.html.markdown
+++ b/website/docs/r/firestore_document.html.markdown
@@ -45,7 +45,7 @@ the App Engine location specified.
 resource "google_firestore_document" "mydoc" {
   project     = "my-project-name"
   collection  = "somenewcollection"
-  document_id = "my-doc-%{random_suffix}"
+  document_id = "my-doc"
   fields      = "{\"something\":{\"mapValue\":{\"fields\":{\"akey\":{\"stringValue\":\"avalue\"}}}}}"
 }
 ```
@@ -56,7 +56,7 @@ resource "google_firestore_document" "mydoc" {
 resource "google_firestore_document" "mydoc" {
   project     = "my-project-name"
   collection  = "somenewcollection"
-  document_id = "my-doc-%{random_suffix}"
+  document_id = "my-doc"
   fields      = "{\"something\":{\"mapValue\":{\"fields\":{\"akey\":{\"stringValue\":\"avalue\"}}}}}"
 }
 

--- a/website/docs/r/iam_deny_policy.html.markdown
+++ b/website/docs/r/iam_deny_policy.html.markdown
@@ -39,8 +39,8 @@ To get more information about DenyPolicy, see:
 ```hcl
 resource "google_project" "project" {
   provider        = google-beta
-  project_id      = "tf-test%{random_suffix}"
-  name            = "tf-test%{random_suffix}"
+  project_id      = "tf-test"
+  name            = "tf-test"
   org_id          = "123456789"
   billing_account = "000000-0000000-0000000-000000"
 }

--- a/website/docs/r/iap_brand.html.markdown
+++ b/website/docs/r/iap_brand.html.markdown
@@ -42,8 +42,8 @@ To get more information about Brand, see:
 
 ```hcl
 resource "google_project" "project" {
-  project_id = "tf-test%{random_suffix}"
-  name       = "tf-test%{random_suffix}"
+  project_id = "tf-test"
+  name       = "tf-test"
   org_id     = "123456789"
 }
 

--- a/website/docs/r/iap_client.html.markdown
+++ b/website/docs/r/iap_client.html.markdown
@@ -43,8 +43,8 @@ state as plain-text. [Read more about secrets in state](https://www.pulumi.com/d
 
 ```hcl
 resource "google_project" "project" {
-  project_id = "tf-test%{random_suffix}"
-  name       = "tf-test%{random_suffix}"
+  project_id = "tf-test"
+  name       = "tf-test"
   org_id     = "123456789"
 }
 

--- a/website/docs/r/tpu_node.html.markdown
+++ b/website/docs/r/tpu_node.html.markdown
@@ -92,7 +92,7 @@ data "google_compute_network" "network" {
 }
 
 resource "google_compute_global_address" "service_range" {
-  name          = "tf-test%{random_suffix}"
+  name          = "tf-test"
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 16


### PR DESCRIPTION
%{random_suffix} is not valid HCL and is causing examples to be dropped from the provider docs.

When running tfgen in pulumi-gcp against this branch, the amount of resource examples failing to convert is reduced from 74 to 50. 